### PR TITLE
Dont meddle with core private data (OpenCPN#2312).

### DIFF
--- a/src/watchdog_pi.cpp
+++ b/src/watchdog_pi.cpp
@@ -631,7 +631,7 @@ void watchdog_pi::ShowConfigurationDialog( wxWindow* )
 wxString watchdog_pi::StandardPath()
 {
     wxString s = wxFileName::GetPathSeparator();
-    wxString stdPath  = *GetpPrivateApplicationDataLocation();
+    wxString stdPath(*GetpPrivateApplicationDataLocation());
     stdPath += s + _T("plugins");
     if (!wxDirExists(stdPath))
         wxMkdir(stdPath);


### PR DESCRIPTION
Current code meddles with private data in OCPNPlatform, see https://github.com/OpenCPN/OpenCPN/issues/2312.  Use a private copy of the string instead of updating the one returned by `GetpPrivateApplicationDataLocation()`