### PR TITLE
Fix XTE visual representation

### DIFF
--- a/src/WatchdogUI.cpp
+++ b/src/WatchdogUI.cpp
@@ -887,7 +887,7 @@ SpeedPanel::SpeedPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, con
 	m_staticText44->Wrap( -1 );
 	fgSizer14->Add( m_staticText44, 0, wxALL, 5 );
 
-	m_tSpeed = new wxTextCtrl( sbSizer7->GetStaticBox(), wxID_ANY, _("1"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_tSpeed = new wxTextCtrl( sbSizer7->GetStaticBox(), wxID_ANY, _("1"), wxDefaultPosition, wxSize(80,-1), 0 );
 	#ifdef __WXGTK__
 	if ( !m_tSpeed->HasFlag( wxTE_MULTILINE ) )
 	{
@@ -1074,7 +1074,7 @@ WeatherPanelBase::WeatherPanelBase( wxWindow* parent, wxWindowID id, const wxPoi
 	m_staticText511->Wrap( -1 );
 	fgSizer14->Add( m_staticText511, 0, wxALL, 5 );
 
-	m_tValue = new wxTextCtrl( sbSizer7->GetStaticBox(), wxID_ANY, _("1010"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_tValue = new wxTextCtrl( sbSizer7->GetStaticBox(), wxID_ANY, _("1010"), wxDefaultPosition, wxSize(80,-1), 0 );
 	fgSizer14->Add( m_tValue, 0, wxALL, 5 );
 
 	m_stUnits = new wxStaticText( sbSizer7->GetStaticBox(), wxID_ANY, _("mBar/C/%"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1234,7 +1234,7 @@ DepthPanel::DepthPanel( wxWindow* parent, wxWindowID id, const wxPoint& pos, con
 	m_staticText44->Wrap( -1 );
 	fgSizer14->Add( m_staticText44, 0, wxALL, 5 );
 
-	m_tDepth = new wxTextCtrl( sbSizer7->GetStaticBox(), wxID_ANY, _("1"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_tDepth = new wxTextCtrl( sbSizer7->GetStaticBox(), wxID_ANY, _("1"), wxDefaultPosition, wxSize(80,-1), 0 );
 	#ifdef __WXGTK__
 	if ( !m_tDepth->HasFlag( wxTE_MULTILINE ) )
 	{
@@ -1310,7 +1310,7 @@ LandFallPanel::LandFallPanel( wxWindow* parent, wxWindowID id, const wxPoint& po
 	m_rbDistance = new wxRadioButton( this, wxID_ANY, _("GPS fix is <"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer10->Add( m_rbDistance, 0, wxALL, 5 );
 
-	m_tDistance = new wxTextCtrl( this, wxID_ANY, _("3"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_tDistance = new wxTextCtrl( this, wxID_ANY, _("3"), wxDefaultPosition, wxSize(80,-1), 0 );
 	#ifdef __WXGTK__
 	if ( !m_tDistance->HasFlag( wxTE_MULTILINE ) )
 	{
@@ -1379,7 +1379,7 @@ BoundaryPanel::BoundaryPanel( wxWindow* parent, wxWindowID id, const wxPoint& po
 	m_rbDistance = new wxRadioButton( this, GPSFIX, _("GPS fix is <"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer10->Add( m_rbDistance, 0, wxALL, 5 );
 
-	m_tDistance = new wxTextCtrl( this, wxID_ANY, _("3"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_tDistance = new wxTextCtrl( this, wxID_ANY, _("3"), wxDefaultPosition, wxSize(80,-1), 0 );
 	#ifdef __WXGTK__
 	if ( !m_tDistance->HasFlag( wxTE_MULTILINE ) )
 	{


### PR DESCRIPTION
**Problem**: The XTE alarm's corridor visualization was incorrectly centered on the boat's position, making it appear that the boat was always on the intended track centerline. This defeated the purpose of visualizing cross-track error.

**Solution**:

1. Corrected corridor positioning: The corridor now represents the true intended track line, independent of the boat's current position
2. Uses XTE data to determine where the boat should be on the bearing line, then builds the corridor around that intended track
3. Limited to 1 nautical mile forward for practical visualization, regardless of waypoint distance
4. Blue line shows cross-track error as perpendicular distance to intended track
Blue circle marks where boat should be on the intended track

If the boat is within the XTE max configured limit, the rectangle color is green:

<img width="869" alt="image" src="https://github.com/user-attachments/assets/722e37ca-f214-4015-8aba-ed1b998181a9" />

If the boat is outside the XTE max configured limit, the rectangle color is red:
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/e2dee45c-1437-4aac-8c63-d16f0726dadb" />

The size of the rectangle is max 1nm to ensure it does not project too far ahead if the distance to the waypoint is large.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/34d11bbd-0778-4461-af57-f5bd02b769cd" />


